### PR TITLE
Fixes JavaScript syntax error

### DIFF
--- a/XMLWriter.js
+++ b/XMLWriter.js
@@ -82,6 +82,8 @@ XMLWriter.prototype = {
 	},
 	//add a text node wrapped with CDATA
 	writeCDATA:function( text ){
+		// keep nested CDATA
+		text = text.replace(/>>]/g, "]]><![CDATA[>");
 		this.writeString( '<![CDATA[' + text + ']]>' );
 	},
 	//add a text node wrapped in a comment


### PR DESCRIPTION
Chrome doesn't want to load the file as a "," is missing. Therefore, I'm proposing this patch.
