### PR TITLE
Enable writing prepared XML elements

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,13 @@
+Copyright (c) 2008, Ariel Flesler
+Copyright (c) 2011, alexandern
+Copyright (c) 2012, alexandern, Mandeepd
+Copyright (c) 2013, alexandern, Oliver Kopp
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README
+++ b/README
@@ -1,1 +1,0 @@
-#XMLWriter - XML generator for Javascript, based on .NET's XMLTextWriter.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # XMLWriter
 
+## About this repository
+
+The official repository is now https://github.com/flesler/XMLWriter.
+Currently, the updates from here are pushed into the official repository.
+This repository is only for historical reasons and will be deleted soon.
+
+## About XMLWriter
+
 XMLWriter is an XML generator for Javascript, based on .NET's XMLTextWriter.
 
 The original version has been published at http://flesler.blogspot.de/2008/03/xmlwriter-for-javascript.html.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# XMLWriter
+
+XMLWriter is an XML generator for Javascript, based on .NET's XMLTextWriter.
+
+The original version has been published at http://flesler.blogspot.de/2008/03/xmlwriter-for-javascript.html.
+
+It was published originally at github on https://github.com/alexandern/XMLWriter.
+

--- a/XMLWriter.js
+++ b/XMLWriter.js
@@ -2,13 +2,13 @@
  * XMLWriter - XML generator for Javascript, based on .NET's XMLTextWriter.
  * Copyright (c) 2008 Ariel Flesler - aflesler(at)gmail(dot)com | http://flesler.blogspot.com
  * Licensed under BSD (http://www.opensource.org/licenses/bsd-license.php)
- * Date: 3/12/2008
- * @version 1.0.0
- * @author Ariel Flesler
- * http://flesler.blogspot.com/2008/03/xmlwriter-for-javascript.html
  *
- *  Modifications:
- *   02/26/2011 - Fixed standalone and added html for escaping (alexandern)
+ * @version 1.1.0
+ * @author Ariel Flesler, alexandern, Mandeepd, Oliver Kopp
+ *
+ * Original version: http://flesler.blogspot.com/2008/03/xmlwriter-for-javascript.html
+ * Current version:  https://github.com/koppor/XMLWriter
+ *
  */
 
 function XMLWriter( encoding, version ){

--- a/XMLWriter.js
+++ b/XMLWriter.js
@@ -74,6 +74,11 @@ XMLWriter.prototype = {
 		if( this.active )
 			this.active.c.push(html(text));
 	},
+	//add plain xml content to the active node without any further checks and escaping
+	writeXML:function( text ){
+		if( this.active )
+			this.active.c.push(text);
+	},
 	//shortcut, open an element, write the text and close
 	writeElementString:function( name, text, ns ){
 		this.writeStartElement( name, ns );


### PR DESCRIPTION
This pull request contains the feature to write prepared XML content (created by other sources).
Furthermore, the already included feature `deleteEndElement` is formally included by a merge.