### PR TITLE
Improve escaping and add methods for writing pre-escaped/XML values

### DIFF
--- a/XMLWriter.js
+++ b/XMLWriter.js
@@ -163,7 +163,7 @@ function html(s) {
 // serialize/parse round-trip.
 // See http://www.w3.org/TR/REC-xml/#AVNormalize for browser parsing rules.
 function htmlAttr(s) {
-	return s.replace(/[&<>"\n\r\t]/g, function (c) { return ESCAPES[c]; });
+	return String(s).replace(/[&<>"\n\r\t]/g, function (c) { return ESCAPES[c]; });
 }
 
 //utility, you don't need it

--- a/XMLWriter.js
+++ b/XMLWriter.js
@@ -2,13 +2,11 @@
  * XMLWriter - XML generator for Javascript, based on .NET's XMLTextWriter.
  * Copyright (c) 2008 Ariel Flesler - aflesler(at)gmail(dot)com | http://flesler.blogspot.com
  * Licensed under BSD (http://www.opensource.org/licenses/bsd-license.php)
- * Date: 3/12/2008
- * @version 1.0.0
- * @author Ariel Flesler
- * http://flesler.blogspot.com/2008/03/xmlwriter-for-javascript.html
  *
- *  Modifications:
- *   02/26/2011 - Fixed standalone and added html for escaping (alexandern)
+ * @version 1.1.0
+ * @author Ariel Flesler, alexandern, Daniel Miller
+ *
+ * Original version: http://flesler.blogspot.com/2008/03/xmlwriter-for-javascript.html
  */
 
 function XMLWriter( encoding, version ){
@@ -69,15 +67,25 @@ XMLWriter.prototype = {
 		if( this.active )
 			this.active.a[name] = html(value);
 	},
-	//add a text node to the active node
+	//add a pre-escaped attribute to the active node
+	writeRawAttributeString:function( name, value ){
+		if( this.active )
+			this.active.a[name] = value;
+	},
+	//add a text node to the active node (XML will be escaped)
 	writeString:function( text ){
 		if( this.active )
 			this.active.c.push(html(text));
 	},
+	//add XML string to the active node without extra escaping
+	writeXML:function( text ){
+		if( this.active )
+			this.active.c.push(text);
+	},
 	//shortcut, open an element, write the text and close
 	writeElementString:function( name, text, ns ){
 		this.writeStartElement( name, ns );
-		this.writeString( html(text) );
+		this.writeString(text);
 		this.writeEndElement();
 	},
 	//add a text node wrapped with CDATA

--- a/XMLWriter.js
+++ b/XMLWriter.js
@@ -65,7 +65,7 @@ XMLWriter.prototype = {
 	//add an attribute to the active node
 	writeAttributeString:function( name, value ){
 		if( this.active )
-			this.active.a[name] = html(value);
+			this.active.a[name] = htmlAttr(value);
 	},
 	//add a pre-escaped attribute to the active node
 	writeRawAttributeString:function( name, value ){
@@ -145,10 +145,26 @@ XMLWriter.prototype = {
 	}
 };
 
+var ESCAPES = {
+	'&': '&amp;',
+	'<': '&lt;',
+	'>': '&gt;',
+	'"': '&quot;',
+	'\t': '&#9;',
+	'\n': '&#10;',
+	'\r': '&#13;'
+};
+
 function html(s) {
-	return s.split('&').join('&amp;').split( '<').join('&lt;').split('>').join('&gt;').split('"').join('&quot;')
+	return s.replace(/[&<>"]/g, function (c) { return ESCAPES[c]; });
 }
 
+// Escape whitespace in attributes so it is preserved during in-browser
+// serialize/parse round-trip.
+// See http://www.w3.org/TR/REC-xml/#AVNormalize for browser parsing rules.
+function htmlAttr(s) {
+	return s.replace(/[&<>"\n\r\t]/g, function (c) { return ESCAPES[c]; });
+}
 
 //utility, you don't need it
 function clean( node ){

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "XMLWriter",
 	"description": "XML generator for Javascript, based on .NET's XMLTextWriter",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"author": {
 		"name": "Ariel Flesler",
 		"email": "aflesler@gmail.com"
@@ -10,6 +10,9 @@
 		{
 			"name": "alex",
 			"email": "alexnolasco@yahoo.com"
+		}, {
+			"name": "Daniel Miller",
+			"email": "dmiller@dimagi.com"
 		}
 	]
 }


### PR DESCRIPTION
- Add `writeXML` and `writeRawAttributeString`.
- Escape whitespace in attributes.
- `writeElementString` no longer double-escapes the string.
