### PR TITLE
Support writing objects that are not strings

### DIFF
--- a/XMLWriter.js
+++ b/XMLWriter.js
@@ -138,6 +138,8 @@ XMLWriter.prototype = {
 };
 
 function html(s) {
+	//Make sure s is a string and not a number or whatever:
+	s = s.toString();
 	return s.split('&').join('&amp;').split( '<').join('&lt;').split('>').join('&gt;').split('"').join('&quot;')
 }
 


### PR DESCRIPTION
I had some "undefined is not a function" when I tried to create attributes that were floats, because you can't invoke split() or join() on them.
This small commit fixes this problem.
